### PR TITLE
feat: support changing canvas margin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# [next]
+- Support configuring margin around the qr code (rendered within the canvas element)
+
 # 5.0.0 - 2021-06-17
 - Support Angular 12
 - Enable "partial-ivy" distribution format - https://angular.io/guide/creating-libraries#building-libraries-with-ivy

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ An optional size in pixels to render the center image.
 
 **Default:** 60
 
+#### margin: number (optional)
+An optional amount of margin to be rendered within the canvas element. Defaults to 4,
+where the unit is the size of one "dot" in the QR code.
+
 ### Directive
 If the provided component is not flexible enough for you, there is also a [directive](projects/ng-qrcode/src/lib/qr-code.directive.ts)
 provided that is used by the [component](projects/ng-qrcode/src/lib/qr-code.component.ts) under the hood, which provides finer 

--- a/projects/ng-qrcode-demo/src/app/app.component.html
+++ b/projects/ng-qrcode-demo/src/app/app.component.html
@@ -42,6 +42,9 @@
       <label for="centerImageSize">Center Image Size</label>
       <input id="centerImageSize" name="centerImageSize" [(ngModel)]="centerImageSize"/>
 
+      <label for="margin">Margin</label>
+      <input id="margin" name="margin" [(ngModel)]="margin"/>
+
     </form>
 
     <h3>Usage:</h3>
@@ -54,7 +57,8 @@
                [size]="size"
                [errorCorrectionLevel]="errorCorrectionLevel"
                [centerImageSrc]="centerImageSrc"
-               [centerImageSize]="centerImageSize ? this.centerImageSize : undefined">
+               [centerImageSize]="centerImageSize ? this.centerImageSize : undefined"
+               [margin]="margin">
       </qr-code>
     </div>
 

--- a/projects/ng-qrcode-demo/src/app/app.component.ts
+++ b/projects/ng-qrcode-demo/src/app/app.component.ts
@@ -14,6 +14,7 @@ export class AppComponent {
   errorCorrectionLevels: QrCodeErrorCorrectionLevel[] = ["L", "M", "Q", "H"]
   showImage = "no"
   centerImageSize = ""
+  margin = 4
 
   get centerImageSrc() {
     return this.showImage === "yes" ? "./assets/angular-logo.png" : undefined
@@ -21,11 +22,12 @@ export class AppComponent {
 
   get example() {
     return `
-<qr-code value="${this.value}"
-         size="${this.size}"
-         errorCorrectionLevel="${this.errorCorrectionLevel}"
-         centerImageSrc="${this.centerImageSrc}"
-         centerImageSize="${this.centerImageSize ? parseInt(this.centerImageSize, 10) : undefined}">
+<qr-code value="${ this.value }"
+         size="${ this.size }"
+         errorCorrectionLevel="${ this.errorCorrectionLevel }"
+         centerImageSrc="${ this.centerImageSrc }"
+         centerImageSize="${ this.centerImageSize ? parseInt(this.centerImageSize, 10) : undefined }"
+         margin="${ this.margin }">
 </qr-code>`
   }
 

--- a/projects/ng-qrcode/src/lib/qr-code.component.ts
+++ b/projects/ng-qrcode/src/lib/qr-code.component.ts
@@ -10,6 +10,7 @@ import { QrCodeErrorCorrectionLevel } from "./types"
             [qrCodeCenterImageSrc]="centerImageSrc"
             [qrCodeCenterImageWidth]="centerImageSize"
             [qrCodeCenterImageHeight]="centerImageSize"
+            [qrCodeMargin]="margin"
             [width]="size"
             [height]="size">
     </canvas>
@@ -32,5 +33,8 @@ export class QrCodeComponent {
 
   @Input()
   centerImageSize?: string | number
+
+  @Input()
+  margin?: number
 
 }

--- a/projects/ng-qrcode/src/lib/qr-code.directive.ts
+++ b/projects/ng-qrcode/src/lib/qr-code.directive.ts
@@ -30,6 +30,9 @@ export class QrCodeDirective implements OnChanges {
   // eslint-disable-next-line @angular-eslint/no-input-rename
   @Input("qrCodeCenterImageHeight") centerImageHeight?: number | string
 
+  // eslint-disable-next-line @angular-eslint/no-input-rename
+  @Input("qrCodeMargin") margin = 16
+
   private centerImage?: HTMLImageElement
 
   constructor(
@@ -68,12 +71,12 @@ export class QrCodeDirective implements OnChanges {
 
     const errorCorrectionLevel = this.errorCorrectionLevel ?? QrCodeDirective.DEFAULT_ERROR_CORRECTION_LEVEL
 
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     await qrcode
       .toCanvas(canvas, this.value, {
         version: this.version,
         errorCorrectionLevel,
         width: this.width,
+        margin: this.margin,
       })
 
     const centerImageSrc = this.centerImageSrc


### PR DESCRIPTION
add new input property "margin" to the component, and "qrCodeMargin" to
the directive that allows configuring the amount of whitespace is
surrounding the image that is output to the canvas.

Keep backwards compatibility by defaulting to 4, however I suspect this
is probably easiest to reason about if it was 0 and normal css padding/margin
was used in it's place, so may change the default in the next major
version.

closes #36