### PR TITLE
feat: Add style and styleClass inputs for utility first CSS integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Controls the amount of redundant information included to make the QR code
 more likely to scan correctly if it is dirty / damaged
 
 #### style: { [klass: string]: any; } (optional)
-Inline style of the element
+Inline style object, passed to the inner canvas element as `[ngStyle]`
 
 #### styleClass: string (optional)
 Class of the element

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ more likely to scan correctly if it is dirty / damaged
 Inline style object, passed to the inner canvas element as `[ngStyle]`
 
 #### styleClass: string (optional)
-Class of the element
+CSS Class, passed to the inner canvas element
 
 **Default:** "M"
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ more likely to scan correctly if it is dirty / damaged
 #### style: { [klass: string]: any; } (optional)
 Inline style of the element
 
-#### styleClass: string
+#### styleClass: string (optional)
 Class of the element
 
 **Default:** "M"

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ If an invalid value is passed, the default will be used.
 Controls the amount of redundant information included to make the QR code 
 more likely to scan correctly if it is dirty / damaged
 
+#### style: { [klass: string]: any; } (optional)
+Inline style of the element
+
+#### styleClass: string
+Class of the element
+
 **Default:** "M"
 
 Valid values: "L", "M", "Q", "H" - where "L" is the lowest 

--- a/README.md
+++ b/README.md
@@ -53,15 +53,15 @@ If an invalid value is passed, the default will be used.
 
 **Default** white ("#FFFFFFFF")
 
-#### errorCorrectionLevel: string (optional)
-Controls the amount of redundant information included to make the QR code 
-more likely to scan correctly if it is dirty / damaged
-
 #### style: { [klass: string]: any; } (optional)
 Inline style object, passed to the inner canvas element as `[ngStyle]`
 
 #### styleClass: string (optional)
 CSS Class, passed to the inner canvas element
+
+#### errorCorrectionLevel: string (optional)
+Controls the amount of redundant information included to make the QR code 
+more likely to scan correctly if it is dirty / damaged
 
 **Default:** "M"
 

--- a/projects/ng-qrcode/src/lib/qr-code.component.ts
+++ b/projects/ng-qrcode/src/lib/qr-code.component.ts
@@ -33,7 +33,11 @@ export class QrCodeComponent {
   size?: string | number
 
   @Input()
-  style?: { [klass: string]: any } | null;
+  style?: { 
+    // matches type of ngStyle https://angular.io/api/common/NgStyle
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    [klass: string]: any 
+  } | null;
 
   @Input()
   styleClass?: string;

--- a/projects/ng-qrcode/src/lib/qr-code.component.ts
+++ b/projects/ng-qrcode/src/lib/qr-code.component.ts
@@ -14,6 +14,8 @@ import { QrCodeErrorCorrectionLevel, RGBAColor } from "./types"
         [qrCodeMargin]="margin"
         [width]="size"
         [height]="size"
+        [class]="styleClass"
+        [ngStyle]="style"
         [darkColor]="darkColor"
         [lightColor]="lightColor"
       >
@@ -29,6 +31,12 @@ export class QrCodeComponent {
 
   @Input()
   size?: string | number
+
+  @Input()
+  style?: { [klass: string]: any } | null;
+
+  @Input()
+  styleClass?: string;
 
   @Input()
   darkColor?: RGBAColor


### PR DESCRIPTION
I would like to propose the additions of two new inputs: `style` and `styleClass`. These allow for internal styling of the rendered HTML via utility libraries such as Tailwind.