### PR TITLE
fix: return QrCodeModule to avoid breaking change

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,18 @@
+# 19.0.1 - 2025-01-05
+- Bring back `QrCodeModule` for backwards compatibility
+
 # 19.0.0 - 2025-01-05
 - Support Angular 19 (#106)
+- `QrCodeComponent` and `QrCodeDirective` are now `standalone` components 
 
+<strike>
 *BREAKING CHANGES:* 
 - `QrCodeComponent` and `QrCodeDirective` are now `standalone` components
 - `QrCodeModule` has been removed
+</strike>
+
+Update: 19.0.1 brings back the `QrCodeModule` such that this should be a non-breaking change. It's
+still recommended to migrate away from using the `QrCodeModule`
 
 See the [readme](https://github.com/mnahkies/ng-qrcode#importing) for instructions on how to import the 
 components correctly after these changes, but **tldr; replace imports of `QrCodeModule` with `QrCodeComponent`** 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,5 @@
 # 19.0.1 - 2025-01-05
-- Bring back `QrCodeModule` for backwards compatibility
+- Bring back `QrCodeModule` for backwards compatibility (#109)
 
 # 19.0.0 - 2025-01-05
 - Support Angular 19 (#106)

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ import { QrCodeComponent } from 'ng-qrcode';
 })
 ```
 
+There is also a deprecated `QrCodeModule` that can be imported.
+
 ## Usage
 
 ### Component

--- a/projects/ng-qrcode/package.json
+++ b/projects/ng-qrcode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ng-qrcode",
   "description": "Simple AOT compatible QR code generator for your Angular project.",
-  "version": "19.0.0",
+  "version": "19.0.1",
   "license": "MIT",
   "author": {
     "name": "Michael Nahkies",

--- a/projects/ng-qrcode/src/lib/qr-code.module.ts
+++ b/projects/ng-qrcode/src/lib/qr-code.module.ts
@@ -1,0 +1,23 @@
+import { CommonModule } from "@angular/common"
+import { NgModule } from "@angular/core"
+import { QrCodeComponent } from "./qr-code.component"
+import { QrCodeDirective } from "./qr-code.directive"
+
+/**
+ * @deprecated prefer importing `QrCodeComponent` or `QrCodeDirective` directly
+ */
+@NgModule({
+  declarations: [
+  ],
+  imports: [
+    CommonModule,
+    QrCodeComponent,
+    QrCodeDirective,
+  ],
+  exports: [
+    QrCodeComponent,
+    QrCodeDirective,
+  ],
+})
+export class QrCodeModule {
+}

--- a/projects/ng-qrcode/src/public-api.ts
+++ b/projects/ng-qrcode/src/public-api.ts
@@ -4,4 +4,5 @@
 
 export * from "./lib/qr-code.component"
 export * from "./lib/qr-code.directive"
+export * from './lib/qr-code.module'
 export * from "./lib/types"


### PR DESCRIPTION
As suggested in https://github.com/mnahkies/ng-qrcode/pull/106#issuecomment-2571677877 bring back the `QrCodeModule` as a deprecated symbol to maintain backwards compatibility