### PR TITLE
Fix type for margin and scale

### DIFF
--- a/projects/ng-qrcode/src/lib/qr-code.component.ts
+++ b/projects/ng-qrcode/src/lib/qr-code.component.ts
@@ -65,10 +65,10 @@ export class QrCodeComponent {
   centerImageSize?: string | number
 
   @Input()
-  margin?: number
+  margin?: string | number
 
   @Input()
-  scale?: number
+  scale?: string | number
 
   @Input()
   maskPattern?: QRCodeMaskPattern

--- a/projects/ng-qrcode/src/lib/qr-code.directive.ts
+++ b/projects/ng-qrcode/src/lib/qr-code.directive.ts
@@ -38,10 +38,10 @@ export class QrCodeDirective implements OnChanges {
   @Input("qrCodeCenterImageHeight") centerImageHeight?: number | string
 
   // eslint-disable-next-line @angular-eslint/no-input-rename
-  @Input("qrCodeMargin") margin?: number = 16
+  @Input("qrCodeMargin") margin?: number | string = 16
 
   @Input()
-  qrScale?: number | undefined
+  qrScale?: number | string | undefined
 
   @Input()
   qrCodeMaskPattern?: QRCodeMaskPattern | undefined
@@ -103,8 +103,8 @@ export class QrCodeDirective implements OnChanges {
         version: this.version,
         errorCorrectionLevel,
         width: getOptionalInt(this.width),
-        margin: this.margin,
-        scale: this.qrScale,
+        margin: getOptionalInt(this.margin),
+        scale: getOptionalInt(this.qrScale),
         maskPattern: this.qrCodeMaskPattern,
         color: {
           dark,


### PR DESCRIPTION
I have made a fix to the type, so there is no need for dynamic binding of margin or scale.
For example:
```
<qr-code value="Hello world!" margin="2" scale="2" />
```